### PR TITLE
adding margin top option

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1231,10 +1231,11 @@ ClusterIcon.prototype.createCss = function(pos) {
 
   var txtColor = this.textColor_ ? this.textColor_ : 'black';
   var txtSize = this.textSize_ ? this.textSize_ : 11;
+  var marginTop = this.marginTop_ ? this.marginTop_ : 0;
 
   style.push('cursor:pointer; top:' + pos.y + 'px; left:' +
       pos.x + 'px; color:' + txtColor + '; position:absolute; font-size:' +
-      txtSize + 'px; font-family:Arial,sans-serif; font-weight:bold');
+      txtSize + 'px; font-family:Arial,sans-serif; font-weight:bold; margin-top:' + marginTop + 'px;');
   return style.join('');
 };
 


### PR DESCRIPTION
I'd like to be able to set a margin top in the style options, small change but one which I've now used on two different projects.

Example usage:
var clusterGroup = new MarkerClusterer($googleMap, markers, {
    gridSize: 40,
    styles: [{
        url: '/images/_temp/map-pin-a.png',
        height: 59,
        width: 30,
        textColor: '#000',
        textSize: 16,
        marginTop: -15
    }]
});

Thanks
