### PR TITLE
In for loop assignment done as second argument

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -898,7 +898,8 @@ Cluster.prototype.getMarkerClusterer = function() {
 Cluster.prototype.getBounds = function() {
   var bounds = new google.maps.LatLngBounds(this.center_, this.center_);
   var markers = this.getMarkers();
-  for (var i = 0, marker; marker = markers[i]; i++) {
+  for (var i=markers.length-1; i>=0; i--) {
+    var marker = markers[i];
     bounds.extend(marker.getPosition());
   }
   return bounds;


### PR DESCRIPTION
The assignment within for loop was done as second argument which throws error and also which is incorrect .Better to do assignment in the first argument of for loop .
