### PR TITLE
add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "js-marker-clusterer",
+  "version": "1.0.0",
+  "description": "The library creates and manages per-zoom-level clusters for large amounts of markers. Google API v3.",
+  "main": "src/markerclusterer.js",
+  "directories": {
+    "doc": "docs",
+    "example": "examples"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/googlemaps/js-marker-clusterer.git"
+  },
+  "keywords": [
+    "google",
+    "marker",
+    "cluster",
+    "clusterer",
+    "javascript",
+    "js",
+    "api",
+    "v3"
+  ],
+  "author": "Luke Mahe",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/googlemaps/js-marker-clusterer/issues"
+  },
+  "homepage": "https://github.com/googlemaps/js-marker-clusterer#readme"
+}


### PR DESCRIPTION
Adding a package.json allows people to `npm install js-marker-clusterer` for use with browserify/webpack (also closes #21). I have already published a `js-marker-clusterer` package that installs googlemaps/js-marker-clusterer, but I can transfer its ownership to you if you wish. 
