### PR TITLE
Update closure compiler externals URL & tweak CSS for cluster icons.

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1,6 +1,6 @@
 // ==ClosureCompiler==
 // @compilation_level ADVANCED_OPTIMIZATIONS
-// @externs_url http://closure-compiler.googlecode.com/svn/trunk/contrib/externs/maps/google_maps_api_v3_3.js
+// @externs_url https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3.js
 // ==/ClosureCompiler==
 
 /**

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1216,7 +1216,9 @@ ClusterIcon.prototype.createCss = function(pos) {
   var style = [];
   style.push('background-image:url(' + this.url_ + ');');
   var backgroundPosition = this.backgroundPosition_ ? this.backgroundPosition_ : '0 0';
+  var backgroundSize = this.width_ > this.height_ ? this.width_ : this.height_;
   style.push('background-position:' + backgroundPosition + ';');
+  style.push('background-size:' + backgroundSize + 'px;');
 
   if (typeof this.anchor_ === 'object') {
     if (typeof this.anchor_[0] === 'number' && this.anchor_[0] > 0 &&


### PR DESCRIPTION
- Updated the closure compiler externals URL to point to its new location on github.
- Added 'background-size' property to CSS for cluster icons to allow for a single image to be used (with the size set by CSS). This also allows for nice big images that render well on higher-resolution displays.
