### PR TITLE
Add cssClass option to override any styles in css

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1225,7 +1225,6 @@ ClusterIcon.prototype.setCenter = function(center) {
  */
 ClusterIcon.prototype.createCss = function(pos) {
   var style = [];
-  var markerClusterer = this.cluster_.getMarkerClusterer();
   style.push('background-image:url(' + this.url_ + ');');
   var backgroundPosition = this.backgroundPosition_ ? this.backgroundPosition_ : '0 0';
   style.push('background-position:' + backgroundPosition + ';');
@@ -1261,7 +1260,6 @@ ClusterIcon.prototype.createCss = function(pos) {
   style.push('cursor:pointer; top:' + pos.y + 'px; left:' +
       pos.x + 'px; color:' + txtColor + '; position:absolute; font-size:' +
       txtSize + 'px; font-family:Arial,sans-serif; font-weight:bold');
-
   return style.join('');
 };
 

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -43,6 +43,8 @@
  *                cluster.
  *     'zoomOnClick': (boolean) Whether the default behaviour of clicking on a
  *                    cluster is to zoom into it.
+ *     'maxZoomOnClick': (number) The maximum zoom level that will be applied to
+ *                       map on click on cluster.
  *     'averageCenter': (boolean) Wether the center of each cluster should be
  *                      the average of all markers in the cluster.
  *     'minimumClusterSize': (number) The minimum number of markers to be in a
@@ -144,6 +146,16 @@ function MarkerClusterer(map, opt_markers, opt_options) {
 
   if (options['zoomOnClick'] != undefined) {
     this.zoomOnClick_ = options['zoomOnClick'];
+  }
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.maxZoomOnClick_ = 20;
+
+  if (options['maxZoomOnClick'] != undefined) {
+    this.maxZoomOnClick_ = options['maxZoomOnClick'];
   }
 
   /**
@@ -1059,6 +1071,9 @@ ClusterIcon.prototype.triggerClusterClick = function(event) {
   google.maps.event.trigger(markerClusterer, 'clusterclick', this.cluster_, event);
 
   if (markerClusterer.isZoomOnClick()) {
+    google.maps.event.addListenerOnce(this.map_, 'bounds_changed', function(e) {
+      if (this.getZoom() > markerClusterer.maxZoomOnClick_) this.setZoom(markerClusterer.maxZoomOnClick_);
+    });
     // Zoom into the cluster.
     this.map_.fitBounds(this.cluster_.getBounds());
   }

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -88,6 +88,11 @@ function MarkerClusterer(map, opt_markers, opt_options) {
   this.styles_ = [];
 
   /**
+   * @private
+   */
+  this.cssClass_ = null;
+
+  /**
    * @type {boolean}
    * @private
    */
@@ -114,6 +119,8 @@ function MarkerClusterer(map, opt_markers, opt_options) {
   this.maxZoom_ = options['maxZoom'] || null;
 
   this.styles_ = options['styles'] || [];
+
+  this.cssClass_ = options['cssClass'] || null;
 
   /**
    * @type {string}
@@ -1068,6 +1075,10 @@ ClusterIcon.prototype.onAdd = function() {
     var pos = this.getPosFromLatLng_(this.center_);
     this.div_.style.cssText = this.createCss(pos);
     this.div_.innerHTML = this.sums_.text;
+    var markerClusterer = this.cluster_.getMarkerClusterer();
+    if (markerClusterer.cssClass_) {
+ 	    this.div_.className = markerClusterer.cssClass_;
+ 	  }
   }
 
   var panes = this.getPanes();
@@ -1214,6 +1225,7 @@ ClusterIcon.prototype.setCenter = function(center) {
  */
 ClusterIcon.prototype.createCss = function(pos) {
   var style = [];
+  var markerClusterer = this.cluster_.getMarkerClusterer();
   style.push('background-image:url(' + this.url_ + ');');
   var backgroundPosition = this.backgroundPosition_ ? this.backgroundPosition_ : '0 0';
   style.push('background-position:' + backgroundPosition + ';');
@@ -1249,6 +1261,7 @@ ClusterIcon.prototype.createCss = function(pos) {
   style.push('cursor:pointer; top:' + pos.y + 'px; left:' +
       pos.x + 'px; color:' + txtColor + '; position:absolute; font-size:' +
       txtSize + 'px; font-family:Arial,sans-serif; font-weight:bold');
+
   return style.join('');
 };
 

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1328,3 +1328,5 @@ Cluster.prototype['getMarkers'] = Cluster.prototype.getMarkers;
 ClusterIcon.prototype['onAdd'] = ClusterIcon.prototype.onAdd;
 ClusterIcon.prototype['draw'] = ClusterIcon.prototype.draw;
 ClusterIcon.prototype['onRemove'] = ClusterIcon.prototype.onRemove;
+
+module.exports = MarkerClusterer;


### PR DESCRIPTION
You can pass cssClass option to add class to each clusterer and override any of properties in css with `!important`.
In js:

```
new MarkerClusterer(map, markers, {cssClass: 'my-clusterer'})
```

In css:

```
.my-clusterer {
  font-size: 40px !important
}
```
