### PR TITLE
When the value of gridSize option is 0, modified to be grouped by the…

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -99,7 +99,7 @@ function MarkerClusterer(map, opt_markers, opt_options) {
    * @type {number}
    * @private
    */
-  this.gridSize_ = options['gridSize'] || 60;
+  this.gridSize_ = (options['gridSize'] !== undefined) ? options['gridSize'] : 60;
 
   /**
    * @private


### PR DESCRIPTION
I want to group by the same coordinates only.
When the value of gridSize option is 0 ,does not work well is converted to 60 .

I modified to be grouped by the same coordinates only , 
When the value of gridSize option is 0.
