### PR TITLE
Update markerclusterer.js

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -188,7 +188,7 @@ function MarkerClusterer(map, opt_markers, opt_options) {
  * @private
  */
 MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_PATH_ =
-    'https://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/' +
+    'https://raw.githubusercontent.com/googlemaps/js-marker-clusterer/gh-pages/' +'
     'images/m';
 
 


### PR DESCRIPTION
We are using this package and google moved their files to github. This points it to the new repo.
