### PR TITLE
Add option to ignore hidden markers

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@
 Luke Mahé <lukem@google.com>
 Brendan Kenny <bckenny@google.com>
 Moisés Arcos <moiarcsan@gmail.com>
+Markus Mächler <markus.maechler@bithost.ch>

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -112,7 +112,7 @@ function MarkerClusterer(map, opt_markers, opt_options) {
    * @type {boolean}
    * @private
    */
-  this.ignoreHiddenMarkers = options['ignoreHiddenMarkers'] || false;
+  this.ignoreHiddenMarkers_ = options['ignoreHiddenMarkers'] || false;
 
   /**
    * @type {?number}
@@ -791,7 +791,7 @@ MarkerClusterer.prototype.createClusters_ = function() {
   var bounds = this.getExtendedBounds(mapBounds);
 
   for (var i = 0, marker; marker = this.markers_[i]; i++) {
-    if (!marker.isAdded && this.isMarkerInBounds_(marker, bounds) && (!this.ignoreHiddenMarkers || marker.getVisible())) {
+    if (!marker.isAdded && this.isMarkerInBounds_(marker, bounds) && (!this.ignoreHiddenMarkers_ || marker.getVisible())) {
       this.addToClosestCluster_(marker);
     }
   }

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -48,6 +48,8 @@
  *     'minimumClusterSize': (number) The minimum number of markers to be in a
  *                           cluster before the markers are hidden and a count
  *                           is shown.
+ *     'ignoreHiddenMarkers': (boolean) Whether to ignore markers that are not
+ *                            visible or count and cluster them anyway
  *     'styles': (object) An object that has style properties:
  *       'url': (string) The image url.
  *       'height': (number) The image height.
@@ -106,6 +108,11 @@ function MarkerClusterer(map, opt_markers, opt_options) {
    */
   this.minClusterSize_ = options['minimumClusterSize'] || 2;
 
+  /**
+   * @type {boolean}
+   * @private
+   */
+  this.ignoreHiddenMarkers = options['ignoreHiddenMarkers'] || false;
 
   /**
    * @type {?number}
@@ -784,7 +791,7 @@ MarkerClusterer.prototype.createClusters_ = function() {
   var bounds = this.getExtendedBounds(mapBounds);
 
   for (var i = 0, marker; marker = this.markers_[i]; i++) {
-    if (!marker.isAdded && this.isMarkerInBounds_(marker, bounds)) {
+    if (!marker.isAdded && this.isMarkerInBounds_(marker, bounds) && (!this.ignoreHiddenMarkers || marker.getVisible())) {
       this.addToClosestCluster_(marker);
     }
   }


### PR DESCRIPTION
I added an option to ignore hidden markers when creating the cluster in the function "createClusters_".
The default value is set to false, which reflects the current state.
