### PR TITLE
Update externs_url for Closure Compiler

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1,6 +1,6 @@
 // ==ClosureCompiler==
 // @compilation_level ADVANCED_OPTIMIZATIONS
-// @externs_url http://closure-compiler.googlecode.com/svn/trunk/contrib/externs/maps/google_maps_api_v3_3.js
+// @externs_url https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/maps/google_maps_api_v3.js
 // ==/ClosureCompiler==
 
 /**


### PR DESCRIPTION
This is a partial duplicate of https://github.com/googlemaps/js-marker-clusterer/pull/30, without the plus-one additions that were delaying that PR.
