### PR TITLE
Only perform click event when not preceded by a drag

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,4 @@ Luke Mahé <lukem@google.com>
 Brendan Kenny <bckenny@google.com>
 Moisés Arcos <moiarcsan@gmail.com>
 Peter Grassberger <petertheone@gmail.com>
+Chris Fritz <us.chrisf@gmail.com>

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1072,8 +1072,18 @@ ClusterIcon.prototype.onAdd = function() {
   panes.overlayMouseTarget.appendChild(this.div_);
 
   var that = this;
+  var isDragging = false;
   google.maps.event.addDomListener(this.div_, 'click', function(event) {
-    that.triggerClusterClick(event);
+    // Only perform click when not preceded by a drag
+    if (!isDragging) {
+      that.triggerClusterClick(event);
+    }
+  });
+  google.maps.event.addDomListener(this.div_, 'mousedown', function() {
+    isDragging = false;
+  });
+  google.maps.event.addDomListener(this.div_, 'mousemove', function() {
+    isDragging = true;
   });
 };
 


### PR DESCRIPTION
When markers are occupying a large portion of the clickable area of the map, it can be frustrating to try to pan about the map and accidentally trigger unwanted click events.

The default behavior for Google Maps markers, presumably in response to this issue, appears to be as follows:
When a drag event occurs between the mousedown and mouseup of a click, the click event is not called.

Here's with the [InfoWindow sample code](https://developers.google.com/maps/documentation/javascript/examples/infowindow-simple) for example:
![marker-behavior](https://cloud.githubusercontent.com/assets/4413963/15729559/5445b2f8-28a0-11e6-979e-9982d1366f91.gif)
## js-marker-clusterer, before

However, js-marker-clusterer, by changing the markers to an overlay, loses this behavior:
![cluster-behavior-before](https://cloud.githubusercontent.com/assets/4413963/15729583/83875616-28a0-11e6-8a22-4547224ef84f.gif)
## js-marker-clusterer, after

This pull request restores the behavior of the markers, as in:
![cluster-behavior-after](https://cloud.githubusercontent.com/assets/4413963/15729595/a0365cb2-28a0-11e6-91e3-8c3c99e03ea9.gif)
