### PR TITLE
Alter license comment to preserve it after Closure Compiler compilation

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -17,8 +17,8 @@
  */
 
 /**
- * @license Apache-2.0
- * Copyright 2010-present, Google Inc.
+ * @license
+ * Copyright 2010 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -17,6 +17,9 @@
  */
 
 /**
+ * @license Apache-2.0
+ * Copyright 2010-present, Google Inc.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
Without a `@license` tag in the license comment, it is squashed by the closure compiler.
With this pull request the result is as follows:

``` js
/*
 Apache-2.0
 Copyright 2010-present, Google Inc.

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
*/
...compiled code
```
