### PR TITLE
allow imagePath to be a function, useful for cache busting

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,3 +14,4 @@ Brendan Kenny <bckenny@google.com>
 Moisés Arcos <moiarcsan@gmail.com>
 Peter Grassberger <petertheone@gmail.com>
 Chris Fritz <us.chrisf@gmail.com>
+Jordan Schroter <jordan.schroter@gmail.com>

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -245,12 +245,12 @@ MarkerClusterer.prototype.setupStyles_ = function() {
   }
 
   for (var i = 0, size; size = this.sizes[i]; i++) {
-    var url = ''
+    var url = '';
 
     if (typeof this.imagePath_ === 'function') {
-      url = this.imagePath_(i, size)
+      url = this.imagePath_(i, size);
     } else {
-      url = this.imagePath_ + (i + 1) + '.' + this.imageExtension_
+      url = this.imagePath_ + (i + 1) + '.' + this.imageExtension_;
     }
 
     this.styles_.push({

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -245,8 +245,16 @@ MarkerClusterer.prototype.setupStyles_ = function() {
   }
 
   for (var i = 0, size; size = this.sizes[i]; i++) {
+    var url = ''
+
+    if (typeof this.imagePath_ === 'function') {
+      url = this.imagePath_(i, size)
+    } else {
+      url = this.imagePath_ + (i + 1) + '.' + this.imageExtension_
+    }
+
     this.styles_.push({
-      url: this.imagePath_ + (i + 1) + '.' + this.imageExtension_,
+      url: url,
       height: size,
       width: size
     });


### PR DESCRIPTION
Adds support for a function to be provided as the imagePath option. The current option doesn't easily allow for cache busting assets. 

Usage:

```
var markerCluster = new MarkerClusterer(map, markers, {
    imagePath: function (i) {
      // would return something like m1-e359da86cb.png
      return imageCache['m' + (i + 1) + '.png']
    }
});
```
