### PR TITLE
Display marker image full width despite label offset

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,3 +14,4 @@ Brendan Kenny <bckenny@google.com>
 Moisés Arcos <moiarcsan@gmail.com>
 Peter Grassberger <petertheone@gmail.com>
 Chris Fritz <us.chrisf@gmail.com>
+Joseph Boiteau <josephboiteau@gmail.com>

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1244,7 +1244,7 @@ ClusterIcon.prototype.createCss = function(pos) {
     }
     if (typeof this.anchor_[1] === 'number' && this.anchor_[1] > 0 &&
         this.anchor_[1] < this.width_) {
-      style.push('width:' + (this.width_ - this.anchor_[1]) +
+      style.push('width:' + this.width_ +
           'px; padding-left:' + this.anchor_[1] + 'px;');
     } else {
       style.push('width:' + this.width_ + 'px; text-align:center;');


### PR DESCRIPTION
Why this code could be used for originally...?

When trying to change the label position:

```
    styles = [{
      ...
      anchor: [-24,32],
      ...
    },{
```

the marker image was getting mangled like so:
![screen shot 2016-10-10 at 11 31 31 am](https://cloud.githubusercontent.com/assets/90534/19225144/64e5a4ae-8ee1-11e6-9106-6b15c438db3e.png)

Once removed, the marker image width is kept fully, the image stay intact despite any offset of the label:
![screen shot 2016-10-10 at 11 32 21 am](https://cloud.githubusercontent.com/assets/90534/19225148/8fa28fa4-8ee1-11e6-9641-63b18ef7c7fb.png)
