### PR TITLE
Update reference.html - getTotalMarkers()

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -351,10 +351,10 @@ This is a v3 implementation of the
                 <td><code>getTotalMarkers()</code></td>
                 
                   
-                    <td><code>Array.<google.maps.Marker></code></td>
+                    <td><code>number<google.maps.Marker></code></td>
                   
                 
-                <td>Gets the array of markers in the clusterer.</td>
+                <td>Gets the number of markers in the clusterer.</td>
               </tr>
             
               <tr class="odd">


### PR DESCRIPTION
Description of getTotalMarkers() is incorrect.
The comment for getTotalMarkers() and in use shows the method returns the number of markers in the clusterer, not an array.
