### PR TITLE
Adding support for css class styling.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,3 +14,4 @@ Brendan Kenny <bckenny@google.com>
 Moisés Arcos <moiarcsan@gmail.com>
 Peter Grassberger <petertheone@gmail.com>
 Chris Fritz <us.chrisf@gmail.com>
+Kevin Candlert <kevinjcandlert@outlook.com>

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -126,6 +126,9 @@ function MarkerClusterer(map, opt_markers, opt_options) {
    */
   this.cssClass_ = options['cssClass'];
 
+  if (this.styles_.length && this.cssClass_)
+    console.warn("A custom style and cssClass is applied. The custom style will be discarded.");
+
   /**
    * @type {string}
    * @private
@@ -189,9 +192,6 @@ function MarkerClusterer(map, opt_markers, opt_options) {
   if (opt_markers && opt_markers.length) {
     this.addMarkers(opt_markers, false);
   }
-
-  if (this.styles_.length && this.cssClass_)
-    console.warn("A custom style and cssClass is applied. The custom style will be discarded.");
 }
 
 

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -126,7 +126,7 @@ function MarkerClusterer(map, opt_markers, opt_options) {
    */
   this.cssClass_ = options['cssClass'];
 
-  if (this.styles_.length && this.cssClass_)
+  if (Object.keys(this.styles_).length > 0 && this.cssClass_)
     console.warn("A custom style and cssClass is applied. The custom style will be discarded.");
 
   /**


### PR DESCRIPTION
I wanted a way to get custom styling from CSS instead of having repeatedly inline CSS for each cluster marker.
If the cssClass options are supplied it will ignore the default styling and the options from the 'styles' parameter.

This is more or less the same feature as #24 but with less white-space changes and different implementation.

