### PR TITLE
Fix mobile touch to zoom. Only perform fast click.

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1075,18 +1075,18 @@ ClusterIcon.prototype.onAdd = function() {
   panes.overlayMouseTarget.appendChild(this.div_);
 
   var that = this;
-  var isDragging = false;
+  var inClickMs = 0;
   google.maps.event.addDomListener(this.div_, 'click', function(event) {
-    // Only perform click when not preceded by a drag
-    if (!isDragging) {
+    // Only perform fast click to zoom
+    if (inClickMs < 300) {
       that.triggerClusterClick(event);
     }
   });
   google.maps.event.addDomListener(this.div_, 'mousedown', function() {
-    isDragging = false;
+    inClickMs = Date.now();
   });
-  google.maps.event.addDomListener(this.div_, 'mousemove', function() {
-    isDragging = true;
+  google.maps.event.addDomListener(this.div_, 'mouseup', function() {
+    inClickMs = Date.now() - inClickMs;
   });
 };
 


### PR DESCRIPTION
Problem with touch device, click on cluster does not trigger 'triggerClusterClick' (and zoom map), because also triggered  'mousemove'. Insted of listening for 'mousemove' i suggest perform touch to zoom only for fast click! This fix work for me, wanna share it. )