### PR TITLE
Trigger event when Clusterer redraw method called

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -708,6 +708,7 @@ MarkerClusterer.prototype.repaint = function() {
  */
 MarkerClusterer.prototype.redraw = function() {
   this.createClusters_();
+  google.maps.event.trigger(this.map_, 'clusters_redrawn', this.clusters_);
 };
 
 


### PR DESCRIPTION
Having an event trigger here will allow the developer to know when the MarkerClusterer is finishing redrawing, and perform additional operations (e.g. manually updating the cluster icons). The paradigm of different clustering icons for 'larger' clusters isn't what we were looking for. The developer can now:

google.maps.event.addListener(myMap, 'clusters_redrawn', function () {
  // Work...
});