### PR TITLE
Update markerclusterer.js

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -190,7 +190,7 @@ function MarkerClusterer(map, opt_markers, opt_options) {
  * @type {string}
  * @private
  */
-MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_PATH_ = '../images/m';
+MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_PATH_ = 'images/m';
 
 
 /**


### PR DESCRIPTION
Previous version would look for the "images" folder in the web root, it now looks for the images in a relative path.
Example: previously, with a website at "www.mydamin.com/somename" the client would look for images in "www.mydomain.com/images", instead of "www.mydomain.com/somename/images"