### PR TITLE
Don't push marker if the marker's map is set to null

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -402,7 +402,9 @@ MarkerClusterer.prototype.getCalculator = function() {
  */
 MarkerClusterer.prototype.addMarkers = function(markers, opt_nodraw) {
   for (var i = 0, marker; marker = markers[i]; i++) {
-    this.pushMarkerTo_(marker);
+    if (marker.getMap() != null){
+      this.pushMarkerTo_(marker);
+    }
   }
   if (!opt_nodraw) {
     this.redraw();


### PR DESCRIPTION
When attempting to filter map markers, the filtered markers still appear.

The widely accepted method of hiding a marker is to use `marker.setMap(null)`. However when using this method in conjunction with the Clusterer, the marker is still pushed to the map regardless of whether or not its map is null.