### PR TITLE
Changed anchor to anchorText, anchor is not defined

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -196,7 +196,7 @@ This is a v3 implementation of the
             <td>The image width.</td>
           </tr>
           <tr>
-            <td><code>anchor</code></td>
+            <td><code>anchorText</code></td>
             <td><code>Array</code></td>
             <td>The anchor position of the label text.</td>
           </tr>


### PR DESCRIPTION
Anchor should be anchorText in the reference, since anchor is not defined. 